### PR TITLE
be compatible with new Search::Elasticsearch

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+ - Made compatible with modern Search::Elasticsearch (6.00)
+
 1.0.3     2018-04-20 14:54:04+02:00 Europe/Oslo
 
  - This module is now officially deprecated

--- a/cpanfile
+++ b/cpanfile
@@ -24,16 +24,10 @@ requires "MooseX::Types::Moose" => "0";
 requires "MooseX::Types::Structured" => "0";
 requires "Scalar::Util" => "0";
 requires "Search::Elasticsearch" => "2.02";
-requires "Search::Elasticsearch::Bulk" => "0";
-requires "Search::Elasticsearch::Scroll" => "0";
 requires "Sub::Exporter" => "0";
 requires "strict" => "0";
 requires "version" => "0";
 requires "warnings" => "0";
-
-on 'build' => sub {
-  requires "Module::Build" => "0.3601";
-};
 
 on 'test' => sub {
   requires "ExtUtils::MakeMaker" => "0";
@@ -55,7 +49,7 @@ on 'test' => sub {
 };
 
 on 'configure' => sub {
-  requires "Module::Build" => "0.28";
+  requires "ExtUtils::MakeMaker" => "0";
 };
 
 on 'develop' => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = BSD
 copyright_holder = Moritz Onken
 main_module = lib/ElasticSearchX/Model.pm
 
-version = 1.0.3
+version = 1.1.0
 
 [Deprecated]
 

--- a/dist.ini
+++ b/dist.ini
@@ -59,7 +59,7 @@ web = https://github.com/CPAN-API/p5-elasticsearch-model
 
 ; -- generate meta files
 [License]
-[ModuleBuild]
+[MakeMaker]
 [MetaYAML]
 [MetaJSON]
 [Readme]

--- a/lib/ElasticSearchX/Model/Bulk.pm
+++ b/lib/ElasticSearchX/Model/Bulk.pm
@@ -1,11 +1,12 @@
 package ElasticSearchX::Model::Bulk;
 
-use Search::Elasticsearch::Bulk;
 use Moose;
+
+use ElasticSearchX::Model::Document::Types qw(ESBulk);
 
 has stash => (
     is         => 'ro',
-    isa        => "Search::Elasticsearch::Bulk",
+    isa        => ESBulk,
     handles    => { stash_size => '_buffer_count', commit => "flush" },
     lazy_build => 1,
 );
@@ -98,7 +99,7 @@ __END__
 
 =head1 DESCRIPTION
 
-This class is a wrapper around L<Search::Elasticsearch::Bulk> which adds
+This class is a wrapper around L<Search::Elasticsearch>'s bulk helper which adds
 some convenience. By specifiying a L</size> you set the maximum
 number of documents that are processed in one request. You can either
 L</put> or L</delete> documents. Once the C<$bulk> object is out

--- a/lib/ElasticSearchX/Model/Document/Types.pm
+++ b/lib/ElasticSearchX/Model/Document/Types.pm
@@ -9,6 +9,7 @@ use DateTime;
 use JSON::MaybeXS qw( decode_json encode_json );
 use Scalar::Util qw(blessed);
 use MooseX::Types::ElasticSearch qw(:all);
+use Moose::Util::TypeConstraints qw(duck_type);
 
 use MooseX::Types -declare => [
     qw(
@@ -16,6 +17,8 @@ use MooseX::Types -declare => [
         Types
         TimestampField
         TTLField
+        ESBulk
+        ESScroll
         )
 ];
 
@@ -25,6 +28,8 @@ use Sub::Exporter -setup => {
             Location
             QueryType
             ES
+            ESBulk
+            ESScroll
             Type
             Types
             TimestampField
@@ -52,6 +57,19 @@ coerce TimestampField, from Str, via {
 coerce TimestampField, from HashRef, via {
     { enabled => 1, %$_ };
 };
+
+subtype ESScroll,
+    as duck_type([qw(
+        next
+        total
+        max_score
+    )]);
+
+subtype ESBulk,
+    as duck_type([qw(
+        _buffer_count
+        flush
+    )]);
 
 subtype TTLField,
     as Dict [

--- a/lib/ElasticSearchX/Model/Role.pm
+++ b/lib/ElasticSearchX/Model/Role.pm
@@ -50,7 +50,7 @@ sub deploy {
         }
         if ( my $alias = $index->alias_for ) {
             my @aliases = keys %{
-                $self->es->indices->get_aliases(
+                $self->es->indices->get_alias(
                     index  => $index->name,
                     ignore => [404]
                     )

--- a/lib/ElasticSearchX/Model/Scroll.pm
+++ b/lib/ElasticSearchX/Model/Scroll.pm
@@ -1,7 +1,8 @@
 package ElasticSearchX::Model::Scroll;
 
 use Moose;
-use Search::Elasticsearch::Scroll;
+
+use ElasticSearchX::Model::Document::Types qw(ESScroll);
 
 has scroll => ( is => 'ro', isa => 'Str', required => 1, default => '1m' );
 
@@ -14,7 +15,7 @@ has set => (
 
 has _scrolled_search => (
     is         => 'ro',
-    isa        => 'Search::Elasticsearch::Scroll',
+    isa        => ESScroll,
     lazy_build => 1,
     handles    => {
         _next     => 'next',
@@ -30,15 +31,12 @@ has qs => (
 
 sub _build__scrolled_search {
     my $self = shift;
-    Search::Elasticsearch::Scroll->new(
-        {
-            es     => $self->set->es,
-            body   => $self->set->_build_query,
-            scroll => $self->scroll,
-            index  => $self->index->name,
-            type   => $self->type->short_name,
-            %{ $self->qs || {} },
-        }
+    $self->set->es->scroll_helper(
+        body   => $self->set->_build_query,
+        scroll => $self->scroll,
+        index  => $self->index->name,
+        type   => $self->type->short_name,
+        %{ $self->qs || {} },
     );
 }
 


### PR DESCRIPTION
Search::Elasticsearch::Bulk and Search::Elasticsearch::Scroll no longer
exist.  Rather than reference them directly, use the helper methods to
contruct them, and use duck typing for their type checks.

The get_aliases method no longer exists for indices, but get_alias does
the same job.